### PR TITLE
Add functionality to create gamedays

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ChaosEngine app nominate randomly a different MoD and On-call person for every G
 The Chaos Engine App is integrated in Mattermost and you can create:
 - Chaos Teams create `/chaos-engine team create --name sre --member @spiros`
 - Chaos Teams list `/chaos-engine team list`
-- Chaos Gamedays create `/chaos-engine gameday create --name chaos-august --team sre --schedule-at 2021-25-08 07:00:00` (pending feature)
+- Chaos Gamedays create `/chaos-engine gameday create --name "Chaos: K8s Node failures" --team sre --schedule-at "2021-25-08 07:00:00"`
 - Chaos Gameday Start `/chaos-engine gameday start --day chaos-august` (pending feature)
 - Chaos Gameday list `/chaos-engine gameday list` (pending feature)
 

--- a/gameday/repository.go
+++ b/gameday/repository.go
@@ -54,6 +54,7 @@ func (r *Repository) ListGamedays() ([]Gameday, error) {
 func (r *Repository) CreateGameday(gameday Gameday) error {
 	insertsMap := map[string]interface{}{
 		"id":           store.NewID(),
+		"title":        gameday.Title,
 		"team_id":      gameday.TeamID,
 		"scheduled_at": gameday.ScheduledAt,
 		"created_at":   time.Now().UnixNano() / int64(time.Millisecond),

--- a/mattermost/transport.go
+++ b/mattermost/transport.go
@@ -52,6 +52,12 @@ func handleBindings(w http.ResponseWriter, r *http.Request, c *apps.CallRequest)
 				Form: &apps.Form{
 					Fields: []*apps.Field{
 						{
+							Type:       "text",
+							Name:       "name",
+							Label:      "name",
+							IsRequired: true,
+						},
+						{
 							Type:       "dynamic_select",
 							Name:       "team",
 							Label:      "team",
@@ -59,8 +65,8 @@ func handleBindings(w http.ResponseWriter, r *http.Request, c *apps.CallRequest)
 						},
 						{
 							Type:        "text",
-							Name:        "schedule-at",
-							Label:       "schedule-at",
+							Name:        "schedule_at",
+							Label:       "schedule_at",
 							Description: "Format [YYYY-DD-MM HH:MM:SS]",
 							IsRequired:  true,
 						},

--- a/store/migrations.go
+++ b/store/migrations.go
@@ -28,6 +28,7 @@ var migrations = []migration{
 		_, err = e.Exec(`
 			CREATE TABLE gameday (
 				id CHAR(26) PRIMARY KEY,
+				title VARCHAR(32) NOT NULL,
 				team_id CHAR(26) NOT NULL,
 				scheduled_at BIGINT NOT NULL,
 				created_at BIGINT NOT NULL,


### PR DESCRIPTION
#### Summary
Ability for `Chaos Engine` users to create and schedule gamedays for the teams which
has been created and formed with `/chaos-engine team` command. The time a user schedules
a gameday `chaos-engine` sends as MM bot DMs to the particular team members.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/MM-38170
