### PR TITLE
Add and enhance Makefile to build Docker and push them in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,77 @@ jobs:
 
   check-modules:
     executor:
-      name: defaultw
+      name: default
     steps:
     - checkout
     - *restore_cache
     - run: make check-modules
     - *save_cache
 
+
+  push-docker-pr:
+    executor:
+      name: default
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run: make build-image push-docker-pr
+    - run:
+        name: Re-run Docker Push if fail
+        command: |
+            sleep 20
+            make push-docker-pr
+        when: on_fail
+
+  push-docker:
+    executor:
+      name: default
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run: make build-image push-docker
+    - run:
+        name: Re-run Docker Push if fail
+        command: |
+            sleep 20
+            make push-docker
+        when: on_fail
+
+  scan-image:
+    docker:
+    - image: registry.gitlab.com/gitlab-org/security-products/analyzers/klar:latest
+      environment:
+        GIT_STRATEGY: none
+        CI_APPLICATION_REPOSITORY: mattermost/mattermost-app-chaosengine
+        CLAIR_DB_CONNECTION_STRING: "postgresql://postgres:password@localhost:5432/postgres?sslmode=disable&statement_timeout=60000"
+        DOCKERFILE_PATH: "build/Dockerfile"
+    - image: arminc/clair-db:latest
+    steps:
+    - checkout
+    - run: |
+        export CI_APPLICATION_TAG="${CIRCLE_SHA1:0:7}"
+        export DOCKER_USER=$DOCKER_USERNAME
+        /analyzer run
+    - store_artifacts:
+        path: gl-container-scanning-report.json
+        destination: security-scan
+
 workflows:
   version: 2
+  
   ci-build:
     jobs:
     - check-style
     - check-modules
+    - push-docker-pr:
+        context: matterbuild-docker
+        requires:
+        - check-style
+        - check-modules
+    - scan-image:
+        context: matterbuild-docker
+        requires:
+        - push-docker-pr
 
   master-build:
     jobs:
@@ -52,3 +110,12 @@ workflows:
           branches:
             only:
             - master
+    - push-docker:
+          context: matterbuild-docker
+          requires:
+          - check-style
+          - check-modules
+          filters:
+            branches:
+              only:
+              - master

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,7 @@
 .history
 
 # Bin
-build/*
-bin/
+build/_output/*
 dist/
 *.zip
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE.txt for license information.
+
+# Build the mattermost chaos-engine app
+ARG DOCKER_BUILD_IMAGE=golang:1.16
+ARG DOCKER_BASE_IMAGE=alpine:3.14
+ARG BUILD_VERSION
+
+FROM ${DOCKER_BUILD_IMAGE} AS build
+WORKDIR /opt/chaosengine
+COPY . /opt/chaosengine
+RUN make build-linux
+
+# Final Image
+FROM ${DOCKER_BASE_IMAGE}
+
+LABEL name="ChaosEngine" \
+  maintainer="cloud-team@mattermost.com" \
+  vendor="Mattermost" \
+  distribution-scope="public" \
+  architecture="x86_64" \
+  url="https://mattermost.com" \
+  io.k8s.description="ChaosEngine is a Mattermost App to run Chaos GameDays as part of your ChatOps." \
+  io.k8s.display-name="Mattermost ChaosEngine"
+
+ENV CHAOS=/chaos/mattermost-app-chaosengine \
+    USER_UID=10001 \
+    USER_NAME=chaos \
+    CHAOS_DIR=/chaos
+
+RUN apk update && apk add libc6-compat && apk add ca-certificates
+COPY --from=build /opt/chaosengine/build/_output/bin/mattermost-app-chaosengine-linux-amd64 /chaos/mattermost-app-chaosengine
+COPY --from=build /opt/chaosengine/build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+WORKDIR /chaos
+
+USER ${USER_UID}
+
+EXPOSE  3000
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# This is documented here:
+# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-chaos}:x:$(id -u):$(id -g):${USER_NAME:-chaos} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${CHAOS} $@

--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+chown ${USER_UID}:0 ${CHAOS_DIR}
+chmod ug+rwx ${CHAOS_DIR}
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm $0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 	// Load config
 	cfg, err := config.Load(logger)
 	if err != nil {
-		log.WithError(err).Error("failed to load config")
+		logger.WithError(err).Error("failed to load config")
 		os.Exit(1)
 		return
 	}
@@ -45,21 +45,21 @@ func main() {
 	var manifest apps.Manifest
 	err = json.Unmarshal(manifestSource, &manifest)
 	if err != nil {
-		log.WithError(err).Error("failed to load manfest")
+		logger.WithError(err).Error("failed to load manfest")
 		os.Exit(1)
 		return
 	}
 
 	store, err := store.New(cfg.Database, logger)
 	if err != nil {
-		log.WithError(err).Error("failed to connect to Database")
+		logger.WithError(err).Error("failed to connect to Database")
 		os.Exit(1)
 		return
 	}
 	// Run migrations on startup
 	err = store.Migrate()
 	if err != nil {
-		log.WithError(err).Error("failed to run migrations")
+		logger.WithError(err).Error("failed to run migrations")
 		os.Exit(1)
 		return
 	}

--- a/scripts/push_docker.sh
+++ b/scripts/push_docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE.txt for license information.
+
+set -e
+set -u
+
+if [[ -z "${CIRCLE_TAG:-}" ]]; then
+  echo "Pushing lastest for $CIRCLE_BRANCH..."
+  TAG=latest
+else
+  echo "Pushing release $CIRCLE_TAG..."
+  TAG="$CIRCLE_TAG"
+fi
+
+echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+
+docker tag mattermost/mattermost-app-chaosengine:test mattermost/mattermost-app-chaosengine:$TAG
+
+docker push mattermost/mattermost-app-chaosengine:$TAG

--- a/scripts/push_docker_pr.sh
+++ b/scripts/push_docker_pr.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE.txt for license information.
+
+set -e
+set -u
+
+export TAG="${CIRCLE_SHA1:0:7}"
+
+echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+
+docker tag mattermost/mattermost/mattermost-app-chaosengine:test mattermost/mattermost/mattermost-app-chaosengine:$TAG
+
+docker push mattermost/mattermost/mattermost-app-chaosengine:$TAG


### PR DESCRIPTION
#### Summary
Implemented a Dockerfile to run Chaos Engine application in your local machine and use only
for test SQLite or configure the docker to use Postgres based on the described in `README.md`.
Updated CircleCI config to build and push the docker images.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/MM-38184

