### PR TITLE
Add gitlab-ci pipeline for creating new releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+# This will run on the internal gitlab
+# Will run only when have a tag pushed
+# Internal GitLab repo: https://git.internal.mattermost.com/mattermost/ci/mattermost-apps
+
+stages:
+  - build
+  - publish
+
+include:
+  - project: mattermost/ci/mattermost-apps
+    ref: main
+    file: private.yml
+
+variables:
+  IMAGE_TO_BUILD: circleci/golang:1.16


### PR DESCRIPTION
#### Summary
Gitlab CI to create chaos engine releases

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/MM-41069

